### PR TITLE
Install CPU-only torch via PyTorch CPU index

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -1,7 +1,7 @@
 python: "3.10"
 commands:
     - ["pip", "pyyaml", "6.0.2"]
-    - ["pip", "torch", "2.6.0"]
+    - ["pip", "torch", "2.6.0", "--index-url", "https://download.pytorch.org/whl/cpu"]
     - ["pip", "numpy", "2.2.4"]
     - ["pip", "pandas", "2.2.3"]
     - ["pip", "torch-geometric", "2.6.1"]


### PR DESCRIPTION
## Problem

`install.yml` pins torch as `["pip", "torch", "2.6.0"]` with no index-url. This causes two failures:

- **amd64**: pip resolves the **CUDA** build of torch, pulling ~2 GB of nvidia libraries. The published image is `~8 GB` (`Image Size: 8075` in metadata), almost entirely CUDA payload the CPU-only model never uses.
- **arm64**: the torch install fails during the emulated multi-arch build and is not caught, so the arm64 image ships with **no `torch` at all** (only `torch-geometric`). At serve time `gather_representation.py` dies on `import torch`; because `main.py` runs it via `subprocess.run(..., stdout=DEVNULL, stderr=DEVNULL)` the error is swallowed and surfaces only as all-empty output columns. `ersilia fetch eos4ex3` then aborts on Apple Silicon with *"Model produced all empty values."*

## Fix

Pin the CPU wheel index, matching the hub-wide convention (eos80k1, eos85mn, eos7ye0, eos9o72, eos8g50, eos2401, the ersilia-pack test fixture, …):

```yaml
- ["pip", "torch", "2.6.0", "--index-url", "https://download.pytorch.org/whl/cpu"]
```

This shrinks the amd64 image (no CUDA) and makes the arm64 build reliable. On arm64 PyPI torch is already `+cpu` (no CUDA wheels exist), so the index-url is harmless there and canonical everywhere.

## Verification

Built locally `FROM` the published image with `torch==2.6.0 --index-url https://download.pytorch.org/whl/cpu` on linux/arm64:
- `torch 2.6.0+cpu`, `torch.version.cuda = None`, no nvidia/cuda/triton packages
- model produces a full `(N, 1000)` embedding matrix with real values, zero empty rows
- `ersilia fetch eos4ex3` then completes successfully on Apple Silicon (M2 Pro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)