### PR TITLE
Remove duplicate Publication key from metadata.yml

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -47,4 +47,3 @@ Computational Performance 2: 26.35
 Computational Performance 3: 32.12
 Computational Performance 4: 88.56
 Computational Performance 5: 331.04
-Publication: https://doi.org/10.1038/s41467-025-58804-4


### PR DESCRIPTION
## Problem

The post-merge **Test and upload model** workflow fails at `add_field_to_metadata.py`:

```
ruamel.yaml.constructor.DuplicateKeyError: while constructing a mapping
found duplicate key "Publication" with value "https://doi.org/10.1038/s41467-025-58804-4"
  in "metadata.yml", line 1, column 1
  ... (original) ... line 50, column 1
```

`metadata.yml` declares `Publication:` **twice** — line 32 and again as the trailing line 50, with the identical value. `ruamel.yaml` rejects duplicate keys, so the upload pipeline errors out on every push to `main`.

This is a pre-existing metadata bug, independent of the recent torch fix (which passed its own `test-model-pr` check).

## Fix

Remove the redundant trailing `Publication:` line. One `Publication:` key (line 32) remains. Verified the file now loads cleanly under `ruamel.yaml` with `allow_duplicate_keys=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)