### PR TITLE
Bump Release to v1.2.1

### DIFF
--- a/metadata.yml
+++ b/metadata.yml
@@ -35,7 +35,7 @@ License: MIT
 Contributor: arnaucoma24
 Incorporation Date: '2025-06-23'
 Last Packaging Date: '2026-06-22'
-Release: v1.2.0
+Release: v1.2.1
 S3: https://ersilia-models-zipped.s3.eu-central-1.amazonaws.com/eos4ex3.zip
 DockerHub: https://hub.docker.com/r/ersiliaos/eos4ex3
 Docker Architecture:


### PR DESCRIPTION
Bumps `metadata.yml` `Release:` from `v1.2.0` to `v1.2.1` so it matches the upcoming `v1.2.1` tag/release.

This release ships:
- CPU-only torch install (PR #5) — fixes the empty-output failure on arm64 and removes the ~8 GB CUDA bloat on amd64. Image is now ~3.6 GB and `Docker Architecture` covers both AMD64 and ARM64.
- Removal of the duplicate `Publication` key in `metadata.yml` (PR #6) — unblocks the upload pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)